### PR TITLE
Add basic RDAP Prometheus exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY rdap_exporter.py .
+
+ENV PORT=8000
+EXPOSE 8000
+
+CMD ["python", "rdap_exporter.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-here goes rdap exporter
+# RDAP Prometheus Exporter
+
+A simple Prometheus exporter that monitors domain information using the
+[rdap.org](https://rdap.org) service.  It fetches data in the background so
+the `/metrics` handler remains fast.
+
+## Usage
+
+```
+export DOMAINS=example.com,example.net
+python rdap_exporter.py
+```
+
+The exporter listens on port `8000` by default.  The following environment
+variables are supported:
+
+- `DOMAINS` – comma separated list of domains to monitor (required)
+- `RDAP_REFRESH_SECONDS` – refresh interval, default `3600`
+- `PORT` – port for the HTTP server, default `8000`
+
+## Docker
+
+```
+docker build -t rdap-exporter .
+docker run -p 8000:8000 -e DOMAINS=example.com,example.net rdap-exporter
+```
+
+## Metrics
+
+- `rdap_domain_expiration_timestamp{domain}` – expiration time (Unix timestamp)
+- `rdap_domain_registration_timestamp{domain}` – registration time
+- `rdap_domain_last_changed_timestamp{domain}` – last change time
+- `rdap_domain_status{domain,status}` – domain status values
+
+## Example alert rules
+
+```
+groups:
+- name: domain-alerts
+  rules:
+  - alert: DomainExpirationSoon
+    expr: (rdap_domain_expiration_timestamp - time()) / 86400 < 30
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      summary: "Domain {{ $labels.domain }} expires in less than 30 days"
+  - alert: DomainExpired
+    expr: rdap_domain_expiration_timestamp < time()
+    for: 1h
+    labels:
+      severity: critical
+    annotations:
+      summary: "Domain {{ $labels.domain }} has expired"
+```

--- a/rdap_exporter.py
+++ b/rdap_exporter.py
@@ -1,0 +1,105 @@
+import os
+import threading
+import time
+import datetime
+from typing import List, Dict, Set
+
+import requests
+from prometheus_client import Gauge, start_http_server
+
+
+def parse_domain_list(value: str) -> List[str]:
+    return [d.strip() for d in value.split(',') if d.strip()]
+
+
+DOMAINS: List[str] = parse_domain_list(os.environ.get('DOMAINS', ''))
+REFRESH_SECONDS: int = int(os.environ.get('RDAP_REFRESH_SECONDS', '3600'))
+PORT: int = int(os.environ.get('PORT', '8000'))
+
+expiration_gauge = Gauge(
+    'rdap_domain_expiration_timestamp',
+    'Expiration time of the domain in Unix epoch seconds',
+    ['domain'],
+)
+registration_gauge = Gauge(
+    'rdap_domain_registration_timestamp',
+    'Registration time of the domain in Unix epoch seconds',
+    ['domain'],
+)
+last_changed_gauge = Gauge(
+    'rdap_domain_last_changed_timestamp',
+    'Last changed time of the domain in Unix epoch seconds',
+    ['domain'],
+)
+status_gauge = Gauge(
+    'rdap_domain_status',
+    'Domain status from RDAP (set to 1 if present)',
+    ['domain', 'status'],
+)
+
+_last_statuses: Dict[str, Set[str]] = {d: set() for d in DOMAINS}
+
+
+def _to_timestamp(date_str: str) -> float:
+    """Convert an ISO 8601 date string to a Unix timestamp."""
+    # Replace trailing Z with +00:00 for fromisoformat
+    return datetime.datetime.fromisoformat(date_str.replace('Z', '+00:00')).timestamp()
+
+
+def update_domain(domain: str) -> None:
+    try:
+        resp = requests.get(f'https://rdap.org/domain/{domain}', timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return
+
+    events = data.get('events', [])
+    for event in events:
+        action = event.get('eventAction')
+        date = event.get('eventDate')
+        if not date:
+            continue
+        ts = _to_timestamp(date)
+        if action == 'expiration':
+            expiration_gauge.labels(domain=domain).set(ts)
+        elif action == 'registration':
+            registration_gauge.labels(domain=domain).set(ts)
+        elif action == 'last changed':
+            last_changed_gauge.labels(domain=domain).set(ts)
+
+    statuses = set(data.get('status', []))
+    for status in statuses:
+        status_gauge.labels(domain=domain, status=status).set(1)
+    # reset statuses not present anymore
+    stale = _last_statuses[domain] - statuses
+    for status in stale:
+        status_gauge.labels(domain=domain, status=status).set(0)
+    _last_statuses[domain] = statuses
+
+
+def fetch_loop() -> None:
+    while True:
+        for domain in DOMAINS:
+            update_domain(domain)
+        time.sleep(REFRESH_SECONDS)
+
+
+def main() -> None:
+    if not DOMAINS:
+        raise SystemExit('DOMAINS environment variable is required')
+
+    start_http_server(PORT)
+    thread = threading.Thread(target=fetch_loop, daemon=True)
+    thread.start()
+
+    # Keep the main thread alive.
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+prometheus_client
+requests


### PR DESCRIPTION
## Summary
- implement RDAP exporter that polls domains in the background and exposes expiration and status metrics
- add Dockerfile and requirements
- document usage, metrics and alerting rules

## Testing
- `python -m py_compile rdap_exporter.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement prometheus_client)*

------
https://chatgpt.com/codex/tasks/task_e_689c9e16696c832192ad114032522d17